### PR TITLE
add darwin function definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,14 @@ NAME = libpapago
 UNAME_S = $(shell uname -s)
 
 CFLAGS  = -O3 -fPIC -Wall -Wextra
-ifeq ($(UNAME_S),FreeBSD)
+ifneq (,$(filter $(UNAME_S),FreeBSD Darwin))
 	CFLAGS += $(shell pkg-config --cflags --libs libwebsockets) \
               $(shell pkg-config --cflags --libs libmicrohttpd) \
 			  $(shell pkg-config --cflags --libs jansson) \
 			  -lssl -lcrypto -lz
+endif
+ifeq ($(UNAME_S),Darwin)
+	CFLAGS += $(shell pkg-config --cflags --libs openssl)
 endif
 TEST_CFLAGS = -g -fPIC -Wall -Wextra
 LDFLAGS = -lwebsockets -lmicrohttpd -ljansson -lssl -lcrypto -lz -lm

--- a/papago.c
+++ b/papago.c
@@ -1414,6 +1414,25 @@ typedef struct {
     size_t pos;
 } memstream_t;
 
+#if defined(__APPLE__)
+static int
+ms_read(void *cookie, char *buf, int size)
+{
+    memstream_t *m = cookie;
+
+    if (m->pos >= m->size)
+        return 0;
+
+    int remain = m->size - m->pos;
+    if (size > remain)
+        size = remain;
+
+    memcpy(buf, m->data + m->pos, size);
+    m->pos += size;
+
+    return size;
+}
+#else
 static ssize_t
 ms_read(void *cookie, char *buf, size_t size)
 {
@@ -1431,7 +1450,35 @@ ms_read(void *cookie, char *buf, size_t size)
 
     return size;
 }
+#endif
 
+#if defined(__APPLE__)
+static int
+ms_write(void *cookie, const char *buf, int size)
+{
+    memstream_t *m = cookie;
+
+    if (m->pos + size + 1 > m->capacity) {
+        size_t newcap = (m->pos + size + 1) * 2;
+        char *newdata = realloc(m->data, newcap);
+        if (!newdata) {
+			return 1;
+		}
+        m->data = newdata;
+        m->capacity = newcap;
+    }
+
+    memcpy(m->data + m->pos, buf, size);
+    m->pos += size;
+
+    if (m->pos > m->size)
+        m->size = m->pos;
+
+    m->data[m->size] = '\0';
+
+    return size;
+}
+#else
 static ssize_t
 ms_write(void *cookie, const char *buf, size_t size)
 {
@@ -1457,7 +1504,35 @@ ms_write(void *cookie, const char *buf, size_t size)
 
     return size;
 }
+#endif
 
+#if defined(__APPLE__)
+static fpos_t
+ms_seek(void *cookie, fpos_t offset, int whence)
+{
+    memstream_t *m = cookie;
+    size_t newpos;
+
+    if (whence == SEEK_SET) {
+        newpos = offset;
+	} else if (whence == SEEK_CUR) {
+        newpos = m->pos + offset;
+    } else if (whence == SEEK_END) {
+        newpos = m->size + offset;
+    } else {
+        return 1;
+    }
+
+    if (newpos > m->size) {
+        return 1;
+	}
+
+    m->pos = newpos;
+    offset = newpos;
+
+    return 0;
+}
+#else
 static int
 ms_seek(void *cookie, off_t *offset, int whence)
 {
@@ -1483,6 +1558,7 @@ ms_seek(void *cookie, off_t *offset, int whence)
 
     return 0;
 }
+#endif
 
 static int
 ms_close(void *cookie)


### PR DESCRIPTION
Since openssl wasn't on the FreeBSD's list I left it out, but it could be on the same expression.

Looks like darwin stdio uses `int` and `fpos_t` instead of `ssize_t`:
```
papago.c:1526:27: error: incompatible function pointer types passing 'ssize_t (void *, char *, size_t)' (aka 'long (void *, char *, unsigned long)') to parameter of type
      'int (* _Nullable)(void *, char *, int)' [-Wincompatible-function-pointer-types]
 1526 |     FILE *fp = funopen(m, ms_read, ms_write, ms_seek, ms_close);
      |                           ^~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:489:22: note: passing argument to parameter here
  489 |                                  int (* _Nullable)(void *, char *_LIBC_COUNT(__n), int __n),
      |                                                  ^
papago.c:1526:36: error: incompatible function pointer types passing 'ssize_t (void *, const char *, size_t)' (aka 'long (void *, const char *, unsigned long)') to parameter of type
      'int (* _Nullable)(void *, const char *, int)' [-Wincompatible-function-pointer-types]
 1526 |     FILE *fp = funopen(m, ms_read, ms_write, ms_seek, ms_close);
      |                                    ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:490:22: note: passing argument to parameter here
  490 |                                  int (* _Nullable)(void *, const char *_LIBC_COUNT(__n), int __n),
      |                                                  ^
papago.c:1526:46: error: incompatible function pointer types passing 'int (void *, off_t *, int)' (aka 'int (void *, long long *, int)') to parameter of type 'fpos_t (* _Nullable)(void *, fpos_t, int)'
      (aka 'long long (*)(void *, long long, int)') [-Wincompatible-function-pointer-types]
 1526 |     FILE *fp = funopen(m, ms_read, ms_write, ms_seek, ms_close);
      |                                              ^~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:491:25: note: passing argument to parameter here
  491 |                                  fpos_t (* _Nullable)(void *, fpos_t, int),
      |                                                     ^
3 errors generated.
make: *** [libpapago.dylib] Error 1
```